### PR TITLE
fix value norm error

### DIFF
--- a/onpolicy/algorithms/r_mappo/r_mappo.py
+++ b/onpolicy/algorithms/r_mappo/r_mappo.py
@@ -171,7 +171,7 @@ class R_MAPPO():
 
         :return train_info: (dict) contains information regarding training update (e.g. loss, grad norms, etc).
         """
-        if self._use_popart:
+        if self._use_popart or self._use_valuenorm:
             advantages = buffer.returns[:-1] - self.value_normalizer.denormalize(buffer.value_preds[:-1])
         else:
             advantages = buffer.returns[:-1] - buffer.value_preds[:-1]


### PR DESCRIPTION
fixes #12

In r_mappo.py, line 175

```
        if self._use_popart:
            advantages = buffer.returns[:-1] - self.value_normalizer.denormalize(buffer.value_preds[:-1])
        else:
            advantages = buffer.returns[:-1] - buffer.value_preds[:-1]
```

should be fixed

```
        if self._use_popart or self._use_valuenorm:
            advantages = buffer.returns[:-1] - self.value_normalizer.denormalize(buffer.value_preds[:-1])
        else:
            advantages = buffer.returns[:-1] - buffer.value_preds[:-1]
```

This error collapses the performance of the PPO.