### PR TITLE
Update mpe_runner.py

### DIFF
--- a/onpolicy/runner/separated/mpe_runner.py
+++ b/onpolicy/runner/separated/mpe_runner.py
@@ -68,8 +68,9 @@ class MPERunner(Runner):
                     for agent_id in range(self.num_agents):
                         idv_rews = []
                         for info in infos:
-                            if 'individual_reward' in infos[agent_id].keys():
-                                idv_rews.append(infos[agent_id]['individual_reward'])
+                            for count, info in enumerate(infos):
+                                if 'individual_reward' in infos[count][agent_id].keys():
+                                    idv_rews.append(infos[count][agent_id].get('individual_reward', 0))
                         train_infos[agent_id].update({'individual_rewards': np.mean(idv_rews)})
                         train_infos[agent_id].update({"average_episode_rewards": np.mean(self.buffer[agent_id].rewards) * self.episode_length})
                 self.log_train(train_infos, total_num_steps)


### PR DESCRIPTION
When using no centralized critic and no shared policy, the previous version of mpe_runner.py didn't work.