### PR TITLE
fixed bug in initializing ValueNorm

### DIFF
--- a/onpolicy/algorithms/r_mappo/r_mappo.py
+++ b/onpolicy/algorithms/r_mappo/r_mappo.py
@@ -45,7 +45,7 @@ class R_MAPPO():
         if self._use_popart:
             self.value_normalizer = self.policy.critic.v_out
         elif self._use_valuenorm:
-            self.value_normalizer = ValueNorm(1).to(self.device)
+            self.value_normalizer = ValueNorm(1, device=self.device)
         else:
             self.value_normalizer = None
 


### PR DESCRIPTION
self.value_normalizer = ValueNorm(1).to(self.device) --> self.value_normalizer = ValueNorm(1, device=self.device) 

in onpolicy/algorithms/r_mappo/r_mappo.py (line 48). 

Running into the following error otherwise: 

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and CPU 
```
